### PR TITLE
Fix comparison of actual page size with inaccurate DIN A4 sizes

### DIFF
--- a/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
+++ b/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
@@ -25,8 +25,8 @@ import java.util.concurrent.Callable;
         description = "Scales large pages scaled down to A4.")
 public class FixPDFCommand implements Callable<Integer> {
 
-    public static final int MAX_WIDTH = 595;
-    public static final int MAX_HEIGHT = 841;
+    public static final float MAX_WIDTH = DIN.A4.getWidth();
+    public static final float MAX_HEIGHT = DIN.A4.getHeight();
 
     @CommandLine.Parameters(index = "0", description = "The input PDF to fix")
     private File inputFile;

--- a/src/test/java/one/squeeze/pdftools/cli/cmds/FixPDFCommandTest.java
+++ b/src/test/java/one/squeeze/pdftools/cli/cmds/FixPDFCommandTest.java
@@ -25,9 +25,7 @@ class FixPDFCommandTest {
     void testBuildScaler_NoopOnA4Portrait() {
         PDPage page = new PDPage();
         PDRectangle box = new PDRectangle();
-        box.setUpperRightX(595);
-        box.setUpperRightY(841);
-        page.setMediaBox(box);
+        page.setMediaBox(DIN.A4);
 
         IScaler scaler = FixPDFCommand.buildScaler(page);
         assertTrue(scaler instanceof NoopScaler);
@@ -37,9 +35,7 @@ class FixPDFCommandTest {
     void testBuildScaler_NoopOnA4Landscape() {
         PDPage page = new PDPage();
         PDRectangle box = new PDRectangle();
-        box.setUpperRightX(841);
-        box.setUpperRightY(595);
-        page.setMediaBox(box);
+        page.setMediaBox(DIN.A4_Landscape);
 
         IScaler scaler = FixPDFCommand.buildScaler(page);
         assertTrue(scaler instanceof NoopScaler);
@@ -49,8 +45,8 @@ class FixPDFCommandTest {
     void testBuildScaler_NoopOnSmallerThanA4Portrait() {
         PDPage page = new PDPage();
         PDRectangle box = new PDRectangle();
-        box.setUpperRightX((float) 595 / 2);
-        box.setUpperRightY((float) 841 / 2);
+        box.setUpperRightX(DIN.A4.getWidth() - 1);
+        box.setUpperRightY(DIN.A4.getHeight() - 1);
         page.setMediaBox(box);
 
         IScaler scaler = FixPDFCommand.buildScaler(page);
@@ -61,8 +57,8 @@ class FixPDFCommandTest {
     void testBuildScaler_NoopOnSmallerThanA4Landscape() {
         PDPage page = new PDPage();
         PDRectangle box = new PDRectangle();
-        box.setUpperRightX((float) 841 / 2);
-        box.setUpperRightY((float) 595 / 2);
+        box.setUpperRightX(DIN.A4_Landscape.getWidth() - 1);
+        box.setUpperRightY(DIN.A4_Landscape.getHeight() - 1);
         page.setMediaBox(box);
 
         IScaler scaler = FixPDFCommand.buildScaler(page);
@@ -73,8 +69,8 @@ class FixPDFCommandTest {
     void testBuildScaler_ScalesLargePortrait() {
         PDPage page = new PDPage();
         PDRectangle box = new PDRectangle();
-        box.setUpperRightX(595 * 10);
-        box.setUpperRightY(841 * 10);
+        box.setUpperRightX(DIN.A4.getWidth() * 10);
+        box.setUpperRightY(DIN.A4.getHeight() * 10);
         page.setMediaBox(box);
 
         Scaler scaler = (Scaler) FixPDFCommand.buildScaler(page);
@@ -86,8 +82,8 @@ class FixPDFCommandTest {
     void testBuildScaler_ScalesLargeLandscape() {
         PDPage page = new PDPage();
         PDRectangle box = new PDRectangle();
-        box.setUpperRightX(841 * 10);
-        box.setUpperRightY(595 * 10);
+        box.setUpperRightX(DIN.A4_Landscape.getWidth() * 10);
+        box.setUpperRightY(DIN.A4_Landscape.getHeight() * 10);
         page.setMediaBox(box);
 
         Scaler scaler = (Scaler) FixPDFCommand.buildScaler(page);


### PR DESCRIPTION
The sizes used previously were not the same values as the ones used in the overall scaling process.