### PR TITLE
Fix failing CI due to permission issues

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,10 +28,9 @@ jobs:
     - name: Test with Maven
       run: mvn test --file pom.xml
 
-# FIXME: The upload of test reports failed in the past, probably due to permission issues.
-#    - name: Upload Test Report
-#      uses: ScaCap/action-surefire-report@v1.7.2
-#      if: success() || failure()
+    - name: Upload Test Report
+      uses: ScaCap/action-surefire-report@v1.7.2
+      if: success() || failure()
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  checks: write
+  contents: write
+  security-events: write
+  statuses: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Relevant literature: https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/