### PR TITLE
Fix scaling to only apply if page area is larger than DIN A4 and US Letter

### DIFF
--- a/src/main/java/one/squeeze/pdftools/US.java
+++ b/src/main/java/one/squeeze/pdftools/US.java
@@ -11,4 +11,8 @@ abstract public class US {
     public static final PDRectangle LEGAL = PDRectangle.LEGAL;
     public static final PDRectangle TABLOID = PDRectangle.TABLOID;
 
+    public static final PDRectangle LETTER_LANDSACPE = new PDRectangle(LETTER.getHeight(), LETTER.getWidth());
+    public static final PDRectangle LEGAL_LANDSACPE = new PDRectangle(LEGAL.getHeight(), LEGAL.getWidth());
+    public static final PDRectangle TABLOID_LANDSACPE = new PDRectangle(TABLOID.getHeight(), TABLOID.getWidth());
+
 }

--- a/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
+++ b/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
@@ -29,6 +29,7 @@ public class FixPDFCommand implements Callable<Integer> {
     public static final PDRectangle TARGET_MEDIA_BOX_LANDSCAPE = DIN.A4_Landscape;
     public static final float MAX_WIDTH = TARGET_MEDIA_BOX.getWidth();
     public static final float MAX_HEIGHT = TARGET_MEDIA_BOX.getHeight();
+    public static final float MAX_AREA = MAX_WIDTH * MAX_HEIGHT;
 
     @CommandLine.Parameters(index = "0", description = "The input PDF to fix")
     private File inputFile;
@@ -66,13 +67,13 @@ public class FixPDFCommand implements Callable<Integer> {
 
     public static boolean shouldScale(PDPage page) {
         PDRectangle mediaBox = page.getMediaBox();
-        boolean isPortrait = mediaBox.getWidth() < mediaBox.getHeight();
 
-        if (isPortrait) {
-            return mediaBox.getWidth() > MAX_WIDTH || mediaBox.getHeight() > MAX_HEIGHT;
-        } else {
-            return mediaBox.getWidth() > MAX_HEIGHT || mediaBox.getHeight() > MAX_WIDTH;
-        }
+        // Pages may be landscape, portrait or other weired aspect rations.
+        // The general concern for us is that the area should not be too large, no matter
+        // what aspect ratio. Thus, we limit the area.
+
+        float area = mediaBox.getWidth() * mediaBox.getHeight();
+        return area > MAX_AREA;
     }
 
     public static IScaler buildScaler(PDPage page) {

--- a/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
+++ b/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
@@ -64,19 +64,25 @@ public class FixPDFCommand implements Callable<Integer> {
         }
     }
 
-    public static IScaler buildScaler(PDPage page) {
+    public static boolean shouldScale(PDPage page) {
         PDRectangle mediaBox = page.getMediaBox();
         boolean isPortrait = mediaBox.getWidth() < mediaBox.getHeight();
-        boolean shouldScale = false;
 
         if (isPortrait) {
-            shouldScale = mediaBox.getWidth() > MAX_WIDTH || mediaBox.getHeight() > MAX_HEIGHT;
+            return mediaBox.getWidth() > MAX_WIDTH || mediaBox.getHeight() > MAX_HEIGHT;
         } else {
-            shouldScale = mediaBox.getWidth() > MAX_HEIGHT || mediaBox.getHeight() > MAX_WIDTH;
+            return mediaBox.getWidth() > MAX_HEIGHT || mediaBox.getHeight() > MAX_WIDTH;
         }
+    }
+
+    public static IScaler buildScaler(PDPage page) {
+        boolean shouldScale = shouldScale(page);
         if (!shouldScale) {
             return new NoopScaler();
         }
+
+        PDRectangle mediaBox = page.getMediaBox();
+        boolean isPortrait = mediaBox.getWidth() < mediaBox.getHeight();
 
         // Calculate scale factors. Depending on the orientation this requires division of height or width.
         float fWidth = 1;

--- a/src/test/java/one/squeeze/pdftools/cli/cmds/FixPDFCommandTest.java
+++ b/src/test/java/one/squeeze/pdftools/cli/cmds/FixPDFCommandTest.java
@@ -1,6 +1,7 @@
 package one.squeeze.pdftools.cli.cmds;
 
 import one.squeeze.pdftools.DIN;
+import one.squeeze.pdftools.US;
 import one.squeeze.pdftools.app.scale.Scaler;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
@@ -18,6 +19,22 @@ class FixPDFCommandTest {
      * Either way, this currently works fine.
      */
     public static final double TEN_PERCENT = 0.10000000149011612;
+
+    @Test
+    void testBuildScaler_NoopOnUsLetterPortrait() {
+        PDPage page = new PDPage();
+        page.setMediaBox(US.LETTER);
+
+        assertFalse(FixPDFCommand.shouldScale(page));
+    }
+
+    @Test
+    void testBuildScaler_NoopOnUsLetterLandscape() {
+        PDPage page = new PDPage();
+        page.setMediaBox(US.LETTER_LANDSACPE);
+
+        assertFalse(FixPDFCommand.shouldScale(page));
+    }
 
     @Test
     void testBuildScaler_NoopOnA4Portrait() {

--- a/src/test/java/one/squeeze/pdftools/cli/cmds/FixPDFCommandTest.java
+++ b/src/test/java/one/squeeze/pdftools/cli/cmds/FixPDFCommandTest.java
@@ -1,15 +1,13 @@
 package one.squeeze.pdftools.cli.cmds;
 
 import one.squeeze.pdftools.DIN;
-import one.squeeze.pdftools.app.scale.IScaler;
-import one.squeeze.pdftools.app.scale.NoopScaler;
 import one.squeeze.pdftools.app.scale.Scaler;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class FixPDFCommandTest {
 
@@ -24,21 +22,17 @@ class FixPDFCommandTest {
     @Test
     void testBuildScaler_NoopOnA4Portrait() {
         PDPage page = new PDPage();
-        PDRectangle box = new PDRectangle();
         page.setMediaBox(DIN.A4);
 
-        IScaler scaler = FixPDFCommand.buildScaler(page);
-        assertTrue(scaler instanceof NoopScaler);
+        assertFalse(FixPDFCommand.shouldScale(page));
     }
 
     @Test
     void testBuildScaler_NoopOnA4Landscape() {
         PDPage page = new PDPage();
-        PDRectangle box = new PDRectangle();
         page.setMediaBox(DIN.A4_Landscape);
 
-        IScaler scaler = FixPDFCommand.buildScaler(page);
-        assertTrue(scaler instanceof NoopScaler);
+        assertFalse(FixPDFCommand.shouldScale(page));
     }
 
     @Test
@@ -49,8 +43,7 @@ class FixPDFCommandTest {
         box.setUpperRightY(DIN.A4.getHeight() - 1);
         page.setMediaBox(box);
 
-        IScaler scaler = FixPDFCommand.buildScaler(page);
-        assertTrue(scaler instanceof NoopScaler);
+        assertFalse(FixPDFCommand.shouldScale(page));
     }
 
     @Test
@@ -61,8 +54,7 @@ class FixPDFCommandTest {
         box.setUpperRightY(DIN.A4_Landscape.getHeight() - 1);
         page.setMediaBox(box);
 
-        IScaler scaler = FixPDFCommand.buildScaler(page);
-        assertTrue(scaler instanceof NoopScaler);
+        assertFalse(FixPDFCommand.shouldScale(page));
     }
 
     @Test


### PR DESCRIPTION
The central change here is that the decision whether to scale or not is now driven by the page area.

This ensures that US letter is not transformed.

This closes #19 