### PR TITLE
Downgrade pdfbox from v3 to v2 to fix processing bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>3.0.2</version>
+            <version>2.0.31</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
+++ b/src/main/java/one/squeeze/pdftools/cli/cmds/FixPDFCommand.java
@@ -5,7 +5,6 @@ import one.squeeze.pdftools.DIN;
 import one.squeeze.pdftools.app.scale.IScaler;
 import one.squeeze.pdftools.app.scale.NoopScaler;
 import one.squeeze.pdftools.app.scale.Scaler;
-import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
@@ -53,7 +52,7 @@ public class FixPDFCommand implements Callable<Integer> {
     }
 
     private static void fix(File input, File output) throws IOException {
-        try (PDDocument pdf = Loader.loadPDF(input)) {
+        try (PDDocument pdf = PDDocument.load(input)) {
             PDPageTree tree = pdf.getPages();
 
             for (PDPage page : tree) {


### PR DESCRIPTION
We had issues handling PDFs with table of contents or bookmarks. It seems that the v2 branch of pdfbox handles those without exceptions while v3 would procude errors such as:

```
java.io.IOException: Error: Unknown type in object stream:COSObject{60, 0}
	at org.apache.pdfbox.pdfwriter.compress.COSWriterObjectStream.writeObject(COSWriterObjectStream.java:238)
	at org.apache.pdfbox.pdfwriter.compress.COSWriterObjectStream.writeCOSDictionary(COSWriterObjectStream.java:341)
	at org.apache.pdfbox.pdfwriter.compress.COSWriterObjectStream.writeObject(COSWriterObjectStream.java:230)
	at org.apache.pdfbox.pdfwriter.compress.COSWriterObjectStream.writeObjectsToStream(COSWriterObjectStream.java:119)
	at org.apache.pdfbox.pdfwriter.COSWriter.doWriteBodyCompressed(COSWriter.java:499)
	at org.apache.pdfbox.pdfwriter.COSWriter.visitFromDocument(COSWriter.java:1307)
```